### PR TITLE
Add SECURITY.md with draft content

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+## How to report
+
+To report a security vulnerability in Islandora, please send an email to security@islandora.ca describing the issue. 
+
+The Security Team may follow up with private discussion in [Slack](https://islandora.slack.com) to resolve the security issue. If you are a part of the Islandora Slack workspace, please include your Slack handle in your email.
+
+## Communication channels
+
+Security updates and announcements are made via the main [Islandora Google Group](https://groups.google.com/g/islandora).


### PR DESCRIPTION
# What does this Pull Request do?

This is an alternative to PR #2 to offer a dedicated "global" choice in the Islandora repositories' "issue type menu" for handling security issues. This serves as a way to keep users from publicly submitting a security concern/bug to the public issue queue.

It would add a new choice like the bottom choice on the following picture...

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/725449/196019031-a1741782-bc95-4eff-b551-856f77a8465e.png">

The text of the new issue type would be...

"...
Report a security vulnerability
Please review our security policy for more details
..."

with a button labeled "View policy."


and the content of the policy will look roughly like this...

<img width="1090" alt="image" src="https://user-images.githubusercontent.com/725449/196019077-2d83f648-8cfa-4a9c-9fac-c0de3e07c62c.png">

Here is an example of the content that will be shown...
https://github.com/ysuarez/.github/security/policy

* **Related GitHub Issue**: 

None issue exists yet, but this PR is in response to PR #2 

* **Other Relevant Links**: (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

Here are the instructions I followed:

https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository


# What's new?


Added a Markdown file called SECURITY.md in the Islandora org ".github" repository.


# How should this be tested?

* Go to any Islandora org repository.
* Create a new issue.
* See if a new issue type choice appears with the following text...

"...
Report a security vulnerability
Please review our security policy for more details
..."

and a button labeled "View policy."


# Interested parties
@Islandora/committers
@DonRichards 